### PR TITLE
Feature/datetime

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ npm install -g martok
 martok ./someFile.d.ts -o Schema.kt --package example
 martok ./someDirectory -o BigSchema.kt
 martok ./someDirectory -o ./outputDirectory # produce lots of little files.
+martok ./someDirectory -o WithDates.kt --datePattern standard # [see Patterns.ts]
 ```
 
 ### SUPPORTS
@@ -42,6 +43,7 @@ martok ./someDirectory -o ./outputDirectory # produce lots of little files.
 * Anonymous types
 * Cross-references to other types
 * kotlinx.serializable
+* kotlinx.datetime
 * Custom package name
 * optional fields
 
@@ -49,6 +51,5 @@ martok ./someDirectory -o ./outputDirectory # produce lots of little files.
 * Complex Unions
 * Anonymous Intersection Types
 * Enums
-* kotlinx.datetime
 * documentation
 * Intended for `.d.ts` files. Work on safer execution for `.ts` 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "martok",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "martok",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "glob": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "martok",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "",
   "main": "dist/src/index.js",
   "bin": "dist/src/index.js",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "tsc",
     "test": "jest",
-    "try": "ts-node src/index.ts tests/comparisons/single/types.d.ts -o ./schema --package net.sarazan.martok",
+    "try": "ts-node src/index.ts tests/comparisons/special/DateTime.d.ts -o ./schema --package net.sarazan.martok --datePattern standard",
     "lint": "eslint . --ext .ts"
   },
   "author": "aaron@sarazan.net",

--- a/src/martok/MartokConfig.ts
+++ b/src/martok/MartokConfig.ts
@@ -1,5 +1,8 @@
+import { MartokOptions } from "./MartokOptions";
+
 export type MartokConfig = {
   package: string;
   files: string[];
   sourceRoot: string;
+  options?: MartokOptions;
 };

--- a/src/martok/MartokOptions.ts
+++ b/src/martok/MartokOptions.ts
@@ -1,0 +1,6 @@
+export type MartokOptions = {
+  dates?: {
+    framework: "kotlinx.datetime";
+    namePattern: RegExp;
+  };
+};

--- a/src/tests/Utils.spec.ts
+++ b/src/tests/Utils.spec.ts
@@ -1,0 +1,14 @@
+import { all } from "../typescript/utils";
+
+describe("Utils Tests", () => {
+  it("Branch validation for [all]", () => {
+    const allFalse = all([0, "string"], (value) => {
+      return typeof value === "string";
+    });
+    expect(allFalse).toBe(false);
+    const allTrue = all(["foo", "bar"], (value) => {
+      return typeof value === "string";
+    });
+    expect(allTrue).toBe(true);
+  });
+});

--- a/src/tests/comparisons.spec.ts
+++ b/src/tests/comparisons.spec.ts
@@ -3,10 +3,10 @@ import { Martok } from "../martok/Martok";
 import * as path from "path";
 import { title } from "../martok/NameGenerators";
 import * as fs from "fs";
-import * as assert from "assert";
 import { sanitizeComparison } from "./sanitizeComparison";
-import _, { values } from "lodash";
+import _ from "lodash";
 import * as util from "util";
+import { StandardDatePattern } from "../typescript/Patterns";
 
 const PACKAGE = "net.sarazan.martok";
 const ROOT = path.resolve("./tests/comparisons");
@@ -57,6 +57,34 @@ describe("Multi File Comparisons", () => {
         );
         expect(out[filename]).toEqual(contents);
       }
+    });
+  }
+});
+
+describe("Special Comparisons", () => {
+  const root = `${ROOT}/special`;
+  {
+    const filename = `${root}/DateTime.d.ts`;
+    const compare = `${path.dirname(filename)}/${title(
+      path.basename(filename, ".d.ts")
+    )}.kt`;
+    it(`${path.basename(filename)} : ${path.basename(compare)}`, async () => {
+      const martok = new Martok({
+        files: [filename],
+        package: PACKAGE,
+        sourceRoot: root,
+        options: {
+          dates: {
+            framework: "kotlinx.datetime",
+            namePattern: StandardDatePattern,
+          },
+        },
+      });
+      const out = sanitizeComparison(martok.generateMultiFile());
+      const contents = sanitizeComparison(
+        await fs.promises.readFile(compare, "utf-8")
+      );
+      expect(out).toEqual(contents);
     });
   }
 });

--- a/src/tests/comparisons.spec.ts
+++ b/src/tests/comparisons.spec.ts
@@ -7,6 +7,7 @@ import { sanitizeComparison } from "./sanitizeComparison";
 import _ from "lodash";
 import * as util from "util";
 import { StandardDatePattern } from "../typescript/Patterns";
+import { ErrorDiscriminate } from "../typescript/UnionHelpers";
 
 const PACKAGE = "net.sarazan.martok";
 const ROOT = path.resolve("./tests/comparisons");
@@ -85,6 +86,18 @@ describe("Special Comparisons", () => {
         await fs.promises.readFile(compare, "utf-8")
       );
       expect(out).toEqual(contents);
+    });
+  }
+
+  {
+    const filename = `${root}/ErrorDiscriminated.d.ts`;
+    it(path.basename(filename), async () => {
+      const martok = new Martok({
+        files: [filename],
+        package: PACKAGE,
+        sourceRoot: root,
+      });
+      expect(() => martok.generateMultiFile()).toThrow(ErrorDiscriminate);
     });
   }
 });

--- a/src/typescript/Patterns.ts
+++ b/src/typescript/Patterns.ts
@@ -1,7 +1,7 @@
 /**
  * Conventions suck, but if you want an easy way to identify date strings in your schemas, this is a pretty good one.
- * The transpiler will recognize numbers as epoch timestamps, and strings as ISO timestamps.
- * Enable this functionality with {TODO}
+ * The transpiler will currently recognize ISO timestamp strings. Epoch numbers are still TODO
+ * Enable this functionality with the -d flag.
  * @match utcFoo;
  * @match isoBar;
  * @match bazDate;

--- a/src/typescript/Patterns.ts
+++ b/src/typescript/Patterns.ts
@@ -1,0 +1,9 @@
+/**
+ * Conventions suck, but if you want an easy way to identify date strings in your schemas, this is a pretty good one.
+ * The transpiler will recognize numbers as epoch timestamps, and strings as ISO timestamps.
+ * Enable this functionality with {TODO}
+ * @match utcFoo;
+ * @match isoBar;
+ * @match bazDate;
+ */
+export const StandardDatePattern = /((^(utc|iso)\w*$)|(Date$))/;

--- a/src/typescript/UnionHelpers.ts
+++ b/src/typescript/UnionHelpers.ts
@@ -1,6 +1,8 @@
 import { TypeChecker, TypeElement, TypeNode } from "typescript";
 import { getMemberType } from "./MemberHelpers";
 
+export const ErrorDiscriminate = `Can't have fully discriminated unions/intersections yet...`;
+
 export function dedupeUnion(
   checker: TypeChecker,
   types: ReadonlyArray<TypeElement>
@@ -14,9 +16,7 @@ export function dedupeUnion(
       return true;
     }
     if (getMemberType(checker, existing) !== type) {
-      throw new Error(
-        `Can't have fully discriminated unions/intersections yet...`
-      );
+      throw new Error(ErrorDiscriminate);
     }
     return false;
   });

--- a/tests/comparisons/special/DateTime.d.ts
+++ b/tests/comparisons/special/DateTime.d.ts
@@ -1,0 +1,6 @@
+export type WithDates = {
+  utcDate1: string;
+  isoDate2: string;
+  fooDate: string;
+  justAString: string;
+};

--- a/tests/comparisons/special/DateTime.kt
+++ b/tests/comparisons/special/DateTime.kt
@@ -1,0 +1,22 @@
+package net.sarazan.martok
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonObject
+
+@Serializable
+data class WithDates(
+    @Serializable(with = kotlinx.datetime.serializers.InstantIso8601Serializer)
+    val utcDate1: Instant,
+    @Serializable(with = kotlinx.datetime.serializers.InstantIso8601Serializer)
+    val isoDate2: Instant,
+    @Serializable(with = kotlinx.datetime.serializers.InstantIso8601Serializer)
+    val fooDate: Instant,
+    val justAString: String
+)

--- a/tests/comparisons/special/DateTime.kt
+++ b/tests/comparisons/special/DateTime.kt
@@ -12,11 +12,11 @@ import kotlinx.serialization.json.JsonObject
 
 @Serializable
 data class WithDates(
-    @Serializable(with = kotlinx.datetime.serializers.InstantIso8601Serializer)
-    val utcDate1: Instant,
-    @Serializable(with = kotlinx.datetime.serializers.InstantIso8601Serializer)
-    val isoDate2: Instant,
-    @Serializable(with = kotlinx.datetime.serializers.InstantIso8601Serializer)
-    val fooDate: Instant,
+    @Serializable(with = kotlinx.datetime.serializers.InstantIso8601Serializer::class)
+    val utcDate1: kotlinx.datetime.Instant,
+    @Serializable(with = kotlinx.datetime.serializers.InstantIso8601Serializer::class)
+    val isoDate2: kotlinx.datetime.Instant,
+    @Serializable(with = kotlinx.datetime.serializers.InstantIso8601Serializer::class)
+    val fooDate: kotlinx.datetime.Instant,
     val justAString: String
 )

--- a/tests/comparisons/special/ErrorDiscriminated.d.ts
+++ b/tests/comparisons/special/ErrorDiscriminated.d.ts
@@ -1,0 +1,9 @@
+export type Foo1 = {
+  foo: string;
+};
+
+export type Foo2 = {
+  foo: number;
+};
+
+export type Foo = Foo1 | Foo2;

--- a/types/DateTime.d.ts
+++ b/types/DateTime.d.ts
@@ -1,0 +1,6 @@
+export type WithDates = {
+  utcDate1: string;
+  isoDate2: string;
+  fooDate: string;
+  justAString: string;
+};


### PR DESCRIPTION
Martok now supports "intelligent" autoconversion of ISO strings to [kotlinx.datetime](https://github.com/Kotlin/kotlinx-datetime).

Add `--datePattern standard` to your CLI args and it will apply the regex `/((^(utc|iso)\w*$)|(Date$))/`. You can also substitute in whatever regex you'd like.

Example:
```
export type WithDates = {
  utcFoo string;
};
```
```
@Serializable
data class WithDates(
    @Serializable(with = kotlinx.datetime.serializers.InstantIso8601Serializer::class)
    val utcDate1: kotlinx.datetime.Instant,
)
```

See Patterns.ts for more context.