### PR TITLE
Fix/enum spacing

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test": "jest",
     "anonymous": "ts-node src/index.ts tests/comparisons/single/anonymous.d.ts -o ./schema/martok --package net.sarazan.martok --datePattern standard",
     "enums": "ts-node src/index.ts tests/comparisons/single/enums.d.ts -o ./schema/martok --package net.sarazan.martok --datePattern standard",
+    "enumSpacing": "ts-node src/index.ts tests/comparisons/single/enumSpacing.d.ts -o ./schema/martok --package net.sarazan.martok --datePattern standard",
     "simpleUnion": "ts-node src/index.ts tests/comparisons/single/simpleUnion.d.ts -o ./schema/martok --package net.sarazan.martok --datePattern standard",
     "types": "ts-node src/index.ts tests/comparisons/single/types.d.ts -o ./schema/martok --package net.sarazan.martok --datePattern standard",
     "tagged": "ts-node src/index.ts tests/comparisons/single/tagged.d.ts -o ./schema/martok --package net.sarazan.martok --datePattern standard",

--- a/src/martok/NameGenerators.ts
+++ b/src/martok/NameGenerators.ts
@@ -4,6 +4,7 @@ export function title(str: string) {
   });
 }
 
+// Adapted from https://stackoverflow.com/a/30521308
 export function pascalToSnake(str: string): string {
   return str
     .replace(/\.?_*([A-Z]+)/g, (letter, index) => {

--- a/src/martok/NameGenerators.ts
+++ b/src/martok/NameGenerators.ts
@@ -5,7 +5,9 @@ export function title(str: string) {
 }
 
 export function pascalToSnake(str: string): string {
-  return str.replace(/[A-Z]/g, (letter, index) => {
-    return index == 0 ? letter.toLowerCase() : "_" + letter.toLowerCase();
-  });
+  return str
+    .replace(/\.?_*([A-Z]+)/g, (letter, index) => {
+      return "_" + index.toLowerCase();
+    })
+    .replace(/^_/, "");
 }

--- a/tests/comparisons/single/EnumSpacing.kt
+++ b/tests/comparisons/single/EnumSpacing.kt
@@ -1,0 +1,36 @@
+package net.sarazan.martok
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonContentPolymorphicSerializer
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonObject
+
+@Serializable(with = Errors.Companion::class)
+enum class Errors(
+    val value: Int
+) {
+    ERROR_ONE(400),
+    ERROR_TWO(401),
+    ERROR_THREE(500);
+    companion object : KSerializer<Errors> {
+        override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("net.sarazan.martok.Errors", PrimitiveKind.INT)
+        override fun deserialize(decoder: Decoder) = when (val value = decoder.decodeInt()) {
+            400 -> ERROR_ONE
+            401 -> ERROR_TWO
+            500 -> ERROR_THREE
+            else   -> throw IllegalArgumentException("Errors could not parse: $value")
+        }
+        override fun serialize(encoder: Encoder, value: Errors) {
+            return encoder.encodeInt(value.value)
+        }
+    }
+}

--- a/tests/comparisons/single/enumSpacing.d.ts
+++ b/tests/comparisons/single/enumSpacing.d.ts
@@ -1,0 +1,5 @@
+export enum Errors {
+  ERROR_ONE = 400,
+  ERROR_TWO = 401,
+  ERROR_THREE = 500,
+}

--- a/tests/comparisons/single/enumSpacing.d.ts
+++ b/tests/comparisons/single/enumSpacing.d.ts
@@ -1,5 +1,5 @@
 export enum Errors {
   ERROR_ONE = 400,
-  ERROR_TWO = 401,
-  ERROR_THREE = 500,
+  error_two = 401,
+  Error_Three = 500,
 }


### PR DESCRIPTION
The pascal-to-snake-case convertor would do exceedingly dumb things if the thing was in shouty snake case already. This is a little smarter