### PR TITLE
Feature/tagged union naming

### DIFF
--- a/src/martok/declarations/TaggedUnionGenerator.ts
+++ b/src/martok/declarations/TaggedUnionGenerator.ts
@@ -187,6 +187,6 @@ ${indentString(tagMapping.join("\n"), 8)}
   }
 
   private capitalizeFirst(value: string): string {
-    return value.replace(/./, c => c.toUpperCase())
+    return value.replace(/./, (c) => c.toUpperCase());
   }
 }

--- a/src/martok/declarations/TaggedUnionGenerator.ts
+++ b/src/martok/declarations/TaggedUnionGenerator.ts
@@ -79,7 +79,7 @@ export class TaggedUnionGenerator {
       )
       .addMembers({
         name: tag.name,
-        type: this.capitalizeFirst(tag.name),
+        type: title(tag.name),
         abstract: true,
       })
       .addInternalClasses(
@@ -146,7 +146,7 @@ export class TaggedUnionGenerator {
         args: [{ name: `"${value}"` }],
       };
     });
-    return new Klass(this.capitalizeFirst(tag.name))
+    return new Klass(title(tag.name))
       .addModifier("enum")
       .setAnnotation("@Serializable")
       .setCtorArgs({ name: "serialName", type: "String", mutability: "val" })
@@ -161,13 +161,13 @@ export class TaggedUnionGenerator {
     const result = [];
     const tagMapping = _.map(tag.mappings, (v, k) => {
       const subName = `${name}${title(k).replace(/\s/g, "_")}`;
-      const tagName = `Tag.${getValName(k)}`;
+      const tagName = `${title(tag.name)}.${getValName(k)}`;
       const subclass = this.martok.declarations.klasses.generate(v, {
         forceName: subName,
         extendSealed: parent,
       }) as Klass;
       const tagMember = subclass.ctor.find((value) => value.name === tag.name);
-      tagMember!.type = `Tag`;
+      tagMember!.type = `${title(tag.name)}`;
       result.push(subclass);
       return `JsonPrimitive(${tagName}.serialName) -> ${subName}.serializer()`;
     });
@@ -184,9 +184,5 @@ ${indentString(tagMapping.join("\n"), 8)}
 }`)
     );
     return result;
-  }
-
-  private capitalizeFirst(value: string): string {
-    return value.replace(/./, (c) => c.toUpperCase());
   }
 }

--- a/src/martok/declarations/TaggedUnionGenerator.ts
+++ b/src/martok/declarations/TaggedUnionGenerator.ts
@@ -79,7 +79,7 @@ export class TaggedUnionGenerator {
       )
       .addMembers({
         name: tag.name,
-        type: "Tag",
+        type: this.capitalizeFirst(tag.name),
         abstract: true,
       })
       .addInternalClasses(
@@ -146,7 +146,7 @@ export class TaggedUnionGenerator {
         args: [{ name: `"${value}"` }],
       };
     });
-    return new Klass("Tag")
+    return new Klass(this.capitalizeFirst(tag.name))
       .addModifier("enum")
       .setAnnotation("@Serializable")
       .setCtorArgs({ name: "serialName", type: "String", mutability: "val" })
@@ -184,5 +184,9 @@ ${indentString(tagMapping.join("\n"), 8)}
 }`)
     );
     return result;
+  }
+
+  private capitalizeFirst(value: string): string {
+    return value.replace(/./, c => c.toUpperCase())
   }
 }

--- a/tests/comparisons/single/Tagged.kt
+++ b/tests/comparisons/single/Tagged.kt
@@ -30,9 +30,9 @@ enum class Types(
 sealed class Tagged {
   abstract val id: String
   abstract val foo: String?
-  abstract val type: Tag
+  abstract val type: Type
   @Serializable
-  enum class Tag(
+  enum class Type(
     val serialName: String
   ) {
     @SerialName("type 1") TYPE_1("type 1"),
@@ -44,7 +44,7 @@ sealed class Tagged {
   data class TaggedType_1(
     override val id: String,
     override val foo: String?,
-    override val type: Tag,
+    override val type: Type,
     val state: State1
   ) : Tagged()
 
@@ -53,7 +53,7 @@ sealed class Tagged {
   data class TaggedType_2(
     override val id: String,
     override val foo: String?,
-    override val type: Tag,
+    override val type: Type,
     val state: State2
   ) : Tagged()
 
@@ -62,8 +62,8 @@ sealed class Tagged {
     override fun selectDeserializer(element: JsonElement) = when(
             val type = element.jsonObject["type"]
         ) {
-            JsonPrimitive(Tag.TYPE_1.serialName) -> TaggedType_1.serializer()
-            JsonPrimitive(Tag.TYPE_2.serialName) -> TaggedType_2.serializer()
+            JsonPrimitive(Type.TYPE_1.serialName) -> TaggedType_1.serializer()
+            JsonPrimitive(Type.TYPE_2.serialName) -> TaggedType_2.serializer()
             else -> throw IllegalArgumentException("Unexpected type: $type")
     }
   }

--- a/tests/comparisons/single/Tagged2.kt
+++ b/tests/comparisons/single/Tagged2.kt
@@ -22,9 +22,9 @@ data class HasId(
 @Serializable(with = IntersectionFirst.UnionSerializer::class)
 sealed class IntersectionFirst {
   abstract val id: String
-  abstract val type: Tag
+  abstract val type: Type
   @Serializable
-  enum class Tag(
+  enum class Type(
     val serialName: String
   ) {
     @SerialName("foo") FOO("foo"),
@@ -35,7 +35,7 @@ sealed class IntersectionFirst {
   @Serializable
   data class IntersectionFirstFoo(
     override val id: String,
-    override val type: Tag,
+    override val type: Type,
     val foo: String
   ) : IntersectionFirst()
 
@@ -43,7 +43,7 @@ sealed class IntersectionFirst {
   @Serializable
   data class IntersectionFirstBar(
     override val id: String,
-    override val type: Tag,
+    override val type: Type,
     val bar: String
   ) : IntersectionFirst()
 
@@ -52,8 +52,8 @@ sealed class IntersectionFirst {
     override fun selectDeserializer(element: JsonElement) = when(
             val type = element.jsonObject["type"]
         ) {
-            JsonPrimitive(Tag.FOO.serialName) -> IntersectionFirstFoo.serializer()
-            JsonPrimitive(Tag.BAR.serialName) -> IntersectionFirstBar.serializer()
+            JsonPrimitive(Type.FOO.serialName) -> IntersectionFirstFoo.serializer()
+            JsonPrimitive(Type.BAR.serialName) -> IntersectionFirstBar.serializer()
             else -> throw IllegalArgumentException("Unexpected type: $type")
     }
   }
@@ -61,9 +61,9 @@ sealed class IntersectionFirst {
 
 @Serializable(with = UnionFirst.UnionSerializer::class)
 sealed class UnionFirst {
-  abstract val type: Tag
+  abstract val type: Type
   @Serializable
-  enum class Tag(
+  enum class Type(
     val serialName: String
   ) {
     @SerialName("foo") FOO("foo"),
@@ -73,7 +73,7 @@ sealed class UnionFirst {
 
   @Serializable
   data class UnionFirstFoo(
-    override val type: Tag,
+    override val type: Type,
     val foo: String,
     val id: String
   ) : UnionFirst()
@@ -81,7 +81,7 @@ sealed class UnionFirst {
 
   @Serializable
   data class UnionFirstBar(
-    override val type: Tag,
+    override val type: Type,
     val bar: String,
     val id: String
   ) : UnionFirst()
@@ -91,8 +91,8 @@ sealed class UnionFirst {
     override fun selectDeserializer(element: JsonElement) = when(
             val type = element.jsonObject["type"]
         ) {
-            JsonPrimitive(Tag.FOO.serialName) -> UnionFirstFoo.serializer()
-            JsonPrimitive(Tag.BAR.serialName) -> UnionFirstBar.serializer()
+            JsonPrimitive(Type.FOO.serialName) -> UnionFirstFoo.serializer()
+            JsonPrimitive(Type.BAR.serialName) -> UnionFirstBar.serializer()
             else -> throw IllegalArgumentException("Unexpected type: $type")
     }
   }

--- a/tests/comparisons/single/Tagged3.kt
+++ b/tests/comparisons/single/Tagged3.kt
@@ -21,9 +21,9 @@ data class NestedLiteralUnion(
 ) {
   @Serializable(with = Data.UnionSerializer::class)
   sealed class Data {
-    abstract val type: Tag
+    abstract val type: Type
     @Serializable
-    enum class Tag(
+    enum class Type(
       val serialName: String
     ) {
       @SerialName("foo") FOO("foo"),
@@ -33,14 +33,14 @@ data class NestedLiteralUnion(
 
     @Serializable
     data class DataFoo(
-      override val type: Tag,
+      override val type: Type,
       val data: Foo
     ) : Data()
 
 
     @Serializable
     data class DataBar(
-      override val type: Tag,
+      override val type: Type,
       val data: Bar
     ) : Data()
 
@@ -49,8 +49,8 @@ data class NestedLiteralUnion(
       override fun selectDeserializer(element: JsonElement) = when(
               val type = element.jsonObject["type"]
           ) {
-              JsonPrimitive(Tag.FOO.serialName) -> DataFoo.serializer()
-              JsonPrimitive(Tag.BAR.serialName) -> DataBar.serializer()
+              JsonPrimitive(Type.FOO.serialName) -> DataFoo.serializer()
+              JsonPrimitive(Type.BAR.serialName) -> DataBar.serializer()
               else -> throw IllegalArgumentException("Unexpected type: $type")
       }
     }


### PR DESCRIPTION
Update how `TaggedUnion` class generation works so the inner classes have the same name as the property/field.