### PR TITLE
Force correct value for tag types in tagged union generation.

### DIFF
--- a/src/martok/declarations/TaggedUnionGenerator.ts
+++ b/src/martok/declarations/TaggedUnionGenerator.ts
@@ -10,20 +10,19 @@ import {
   isTypeLiteralNode,
   isTypeReferenceNode,
   isUnionTypeNode,
-  PropertySignature,
   TypeElement,
   TypeNode,
   UnionTypeNode,
 } from "typescript";
 import { getMembers } from "../../typescript/MemberHelpers";
-import _, { capitalize } from "lodash";
+import _ from "lodash";
 import indentString from "indent-string";
 import { kotlin } from "../../kotlin/Klass";
-import Klass = kotlin.Klass;
 import { SupportedDeclaration } from "./KlassGenerator";
 import { title } from "../NameGenerators";
-import EnumValue = kotlin.EnumValue;
 import { getValName } from "../../typescript/EnumHelpers";
+import Klass = kotlin.Klass;
+import EnumValue = kotlin.EnumValue;
 
 type TagMappings = {
   name: string;
@@ -166,8 +165,11 @@ export class TaggedUnionGenerator {
         forceName: subName,
         extendSealed: parent,
       }) as Klass;
-      const tagMember = subclass.ctor.find((value) => value.name === tag.name);
-      tagMember!.type = `${title(tag.name)}`;
+      const tagMember = subclass.ctor.find((value) => value.name === tag.name)!;
+      _.remove(subclass.ctor, tagMember);
+      tagMember.value = tagName;
+      subclass.addMembers(tagMember);
+      tagMember.type = `${title(tag.name)}`;
       result.push(subclass);
       return `JsonPrimitive(${tagName}.serialName) -> ${subName}.serializer()`;
     });

--- a/src/martok/declarations/TaggedUnionGenerator.ts
+++ b/src/martok/declarations/TaggedUnionGenerator.ts
@@ -166,10 +166,10 @@ export class TaggedUnionGenerator {
         extendSealed: parent,
       }) as Klass;
       const tagMember = subclass.ctor.find((value) => value.name === tag.name)!;
+      tagMember.type = `${title(tag.name)}`;
       _.remove(subclass.ctor, tagMember);
       tagMember.value = tagName;
       subclass.addMembers(tagMember);
-      tagMember.type = `${title(tag.name)}`;
       result.push(subclass);
       return `JsonPrimitive(${tagName}.serialName) -> ${subName}.serializer()`;
     });

--- a/tests/comparisons/single/Tagged.kt
+++ b/tests/comparisons/single/Tagged.kt
@@ -44,18 +44,20 @@ sealed class Tagged {
   data class TaggedType_1(
     override val id: String,
     override val foo: String?,
-    override val type: Type,
     val state: State1
-  ) : Tagged()
+  ) : Tagged() {
+    override val type = Type.TYPE_1
+  }
 
 
   @Serializable
   data class TaggedType_2(
     override val id: String,
     override val foo: String?,
-    override val type: Type,
     val state: State2
-  ) : Tagged()
+  ) : Tagged() {
+    override val type = Type.TYPE_2,
+  }
 
 
   object UnionSerializer : JsonContentPolymorphicSerializer<Tagged>(Tagged::class) {

--- a/tests/comparisons/single/Tagged.kt
+++ b/tests/comparisons/single/Tagged.kt
@@ -46,7 +46,7 @@ sealed class Tagged {
     override val foo: String?,
     val state: State1
   ) : Tagged() {
-    override val type = Type.TYPE_1
+    override val type: Type = Type.TYPE_1
   }
 
 
@@ -56,7 +56,7 @@ sealed class Tagged {
     override val foo: String?,
     val state: State2
   ) : Tagged() {
-    override val type = Type.TYPE_2,
+    override val type: Type = Type.TYPE_2
   }
 
 

--- a/tests/comparisons/single/Tagged2.kt
+++ b/tests/comparisons/single/Tagged2.kt
@@ -37,7 +37,7 @@ sealed class IntersectionFirst {
     override val id: String,
     val foo: String
   ) : IntersectionFirst() {
-    override val type = Type.FOO
+    override val type: Type = Type.FOO
   }
 
 
@@ -46,7 +46,7 @@ sealed class IntersectionFirst {
     override val id: String,
     val bar: String
   ) : IntersectionFirst() {
-    override val type = Type.BAR
+    override val type: Type = Type.BAR
   }
 
 
@@ -75,18 +75,20 @@ sealed class UnionFirst {
 
   @Serializable
   data class UnionFirstFoo(
-    override val type: Type,
     val foo: String,
     val id: String
-  ) : UnionFirst()
+  ) : UnionFirst() {
+    override val type: Type = Type.FOO
+  }
 
 
   @Serializable
   data class UnionFirstBar(
-    override val type: Type,
     val bar: String,
     val id: String
-  ) : UnionFirst()
+  ) : UnionFirst() {
+    override val type: Type = Type.BAR
+  }
 
 
   object UnionSerializer : JsonContentPolymorphicSerializer<UnionFirst>(UnionFirst::class) {

--- a/tests/comparisons/single/Tagged2.kt
+++ b/tests/comparisons/single/Tagged2.kt
@@ -35,17 +35,19 @@ sealed class IntersectionFirst {
   @Serializable
   data class IntersectionFirstFoo(
     override val id: String,
-    override val type: Type,
     val foo: String
-  ) : IntersectionFirst()
+  ) : IntersectionFirst() {
+    override val type = Type.FOO
+  }
 
 
   @Serializable
   data class IntersectionFirstBar(
     override val id: String,
-    override val type: Type,
     val bar: String
-  ) : IntersectionFirst()
+  ) : IntersectionFirst() {
+    override val type = Type.BAR
+  }
 
 
   object UnionSerializer : JsonContentPolymorphicSerializer<IntersectionFirst>(IntersectionFirst::class) {

--- a/tests/comparisons/single/Tagged3.kt
+++ b/tests/comparisons/single/Tagged3.kt
@@ -35,7 +35,7 @@ data class NestedLiteralUnion(
     data class DataFoo(
       val data: Foo
     ) : Data() {
-      override val type = Type.FOO
+      override val type: Type = Type.FOO
     }
 
 
@@ -43,7 +43,7 @@ data class NestedLiteralUnion(
     data class DataBar(
       val data: Bar
     ) : Data() {
-      override val type = Type.BAR
+      override val type: Type = Type.BAR
     }
 
 

--- a/tests/comparisons/single/Tagged3.kt
+++ b/tests/comparisons/single/Tagged3.kt
@@ -33,16 +33,18 @@ data class NestedLiteralUnion(
 
     @Serializable
     data class DataFoo(
-      override val type: Type,
       val data: Foo
-    ) : Data()
+    ) : Data() {
+      override val type = Type.FOO
+    }
 
 
     @Serializable
     data class DataBar(
-      override val type: Type,
       val data: Bar
-    ) : Data()
+    ) : Data() {
+      override val type = Type.BAR
+    }
 
 
     object UnionSerializer : JsonContentPolymorphicSerializer<Data>(Data::class) {


### PR DESCRIPTION
See Tagged.kt, Tagged2.kt, and Tagged3.kt for updated test output.

Example:
```kotlin
  @Serializable
  data class TaggedType_1(
    override val id: String,
    override val foo: String?,
    val state: State1
  ) : Tagged() {
    override val type: Type = Type.TYPE_1
  }
```