### PR TITLE
can now add a `@precision` jsdoc tag to your numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ martok ./someDirectory -o WithDates.kt --datePattern standard # [see Patterns.ts
 * Custom package name
 * Enums
 * optional fields
-* Typescrupt "Utility" types (e.g. `Omit` and `Pick`)
+* Typescript "Utility" types (e.g. `Omit` and `Pick`)
+* Configurable numeric precision via the `@precision` jsdoc tag
 
 ### TODO
 * Fully discriminated/disagreeing unions

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "tsc",
     "test": "jest",
-    "special": "ts-node src/index.ts tests/comparisons/multi/taggedUnions -o ./schema/martok --package net.sarazan.martok --datePattern standard",
+    "special": "ts-node src/index.ts tests/comparisons/single/numbers.d.ts -o ./schema/martok --package net.sarazan.martok --datePattern standard",
     "lint": "eslint . --ext .ts"
   },
   "author": "aaron@sarazan.net",

--- a/src/kotlin/KotlinTypes.ts
+++ b/src/kotlin/KotlinTypes.ts
@@ -1,0 +1,1 @@
+export type KotlinNumber = "Float" | "Double" | "Int" | "Long";

--- a/tests/comparisons/single/Numbers.kt
+++ b/tests/comparisons/single/Numbers.kt
@@ -1,0 +1,27 @@
+package net.sarazan.martok
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonContentPolymorphicSerializer
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonObject
+
+@Serializable
+data class TestNumbers(
+  val someFloat: Float,
+  val someFloats: List<Float>,
+  val someDouble: Double,
+  val someDoubles: List<Double>,
+  val someInt: Int,
+  val someInts: List<Int>,
+  val someLong: Long,
+  val someLongs: List<Long>
+)

--- a/tests/comparisons/single/numbers.d.ts
+++ b/tests/comparisons/single/numbers.d.ts
@@ -1,0 +1,41 @@
+export type TestNumbers = {
+  /**
+   * @precision float
+   */
+  someFloat: number;
+
+  /**
+   * @precision float
+   */
+  someFloats: number[];
+
+  /**
+   * @precision double
+   */
+  someDouble: number;
+
+  /**
+   * @precision double
+   */
+  someDoubles: number[];
+
+  /**
+   * @precision int
+   */
+  someInt: number;
+
+  /**
+   * @precision int
+   */
+  someInts: number[];
+
+  /**
+   * @precision long
+   */
+  someLong: number;
+
+  /**
+   * @precision long
+   */
+  someLongs: number[];
+};


### PR DESCRIPTION
It supports: float, double, int, long. It defaults to double. You can also pass start-cased versions e.g. `Int`