### PR TITLE
move typescript to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
     "nodemon": "^2.0.19",
     "prettier": "^2.4.1",
     "ts-jest": "^27.0.7",
-    "ts-node": "^10.4.0",
-    "typescript": "^4.4.4"
+    "ts-node": "^10.4.0"
   },
   "dependencies": {
     "@typescript/vfs": "^1.4.0",
@@ -39,6 +38,7 @@
     "indent-string": "^4.0.0",
     "lodash": "^4.17.21",
     "promisify": "^0.0.3",
-    "yargs": "^17.2.1"
+    "yargs": "^17.2.1",
+    "typescript": "^4.4.4"
   }
 }


### PR DESCRIPTION
It gets used at runtime, not just as a compiler, so it can't be a devDependency!