### PR TITLE
support wider set of patterns for input

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "martok",
-  "version": "1.8.3-1",
+  "version": "1.8.3-2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "martok",
-      "version": "1.8.3-1",
+      "version": "1.8.3-2",
       "license": "Apache-2.0",
       "dependencies": {
         "@typescript/vfs": "^1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "martok",
-  "version": "1.8.3-2",
+  "version": "1.8.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "martok",
-      "version": "1.8.3-2",
+      "version": "1.8.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@typescript/vfs": "^1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "martok",
-  "version": "1.8.2",
+  "version": "1.8.3-0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "martok",
-      "version": "1.8.2",
+      "version": "1.8.3-0",
       "license": "Apache-2.0",
       "dependencies": {
         "@typescript/vfs": "^1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "martok",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "martok",
-      "version": "1.8.3",
+      "version": "1.8.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@typescript/vfs": "^1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "martok",
-  "version": "1.8.3-0",
+  "version": "1.8.3-1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "martok",
-      "version": "1.8.3-0",
+      "version": "1.8.3-1",
       "license": "Apache-2.0",
       "dependencies": {
         "@typescript/vfs": "^1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "martok",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "martok",
-      "version": "1.8.1",
+      "version": "1.8.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@typescript/vfs": "^1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "martok",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "martok",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@typescript/vfs": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "martok",
-  "version": "1.8.3-2",
+  "version": "1.8.3",
   "description": "",
   "main": "dist/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "martok",
-  "version": "1.8.3-1",
+  "version": "1.8.3-2",
   "description": "",
   "main": "dist/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "tsc",
     "test": "jest",
-    "special": "ts-node src/index.ts tests/errors/imports/expandWithImport.d.ts -i -a -s -t --experimentalTypeExpanding true -o ./schema/martok --package net.sarazan.martok",
+    "special": "ts-node src/index.ts 'tests/globs/declarations/**/*.d.ts' -i -a -s -t -o ./schema/martok --package net.sarazan.martok",
     "lint": "eslint . --ext .ts"
   },
   "author": "aaron@sarazan.net",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "martok",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "",
   "main": "dist/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "martok",
-  "version": "1.8.3-0",
+  "version": "1.8.3-1",
   "description": "",
   "main": "dist/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "martok",
-  "version": "1.8.2",
+  "version": "1.8.3-0",
   "description": "",
   "main": "dist/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "martok",
   "version": "1.8.3",
   "description": "",
-  "main": "dist/index.js",
+  "main": "dist/src/index.js",
   "bin": {
-    "martok": "dist/index.js"
+    "martok": "dist/src/index.js"
   },
   "scripts": {
     "build": "tsc",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "martok",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "description": "",
   "main": "dist/src/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "martok",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "",
   "main": "dist/index.js",
   "bin": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,9 +69,8 @@ async function transpile(args: TranspileSingleArgs) {
   console.log(`Transpile: `, args);
   const getFiles = util.promisify(glob);
   const isDir = (await fs.promises.lstat(args.path)).isDirectory();
-  let files = isDir
-    ? await getFiles(`${args.path}/**/*.{ts,d.ts}`)
-    : [args.path];
+  const pattern = isDir ? `${args.path}/**/*.{ts,d.ts}` : args.path;
+  let files = await getFiles(pattern);
   const rootDir = path.resolve(isDir ? args.path : path.dirname(args.path));
   // Needed for relative imports to work when flattening
   files = files.map((file) => path.resolve(file));

--- a/src/typescript/utils.ts
+++ b/src/typescript/utils.ts
@@ -1,4 +1,8 @@
 import ts from "typescript";
+import util from "util";
+import { glob } from "glob";
+import fs from "fs";
+import path from "path";
 
 export function all<T>(
   arr: ReadonlyArray<T>,
@@ -25,4 +29,25 @@ export function hasTypeArguments(
   node: any
 ): node is ts.ExpressionWithTypeArguments {
   return node && node.typeArguments && node.typeArguments.length > 0;
+}
+
+export async function resolveFiles(args: {
+  path: string;
+}): Promise<{ files: string[]; rootDir: string }> {
+  const getFiles = util.promisify(glob);
+  let isDir = false;
+  try {
+    isDir = (await fs.promises.lstat(args.path)).isDirectory();
+  } catch (e: unknown) {
+    console.log(`Using pattern lookup for ${args.path}...`);
+  }
+  const pattern = isDir ? `${args.path}/**/*.{ts,d.ts}` : args.path;
+  const files = await getFiles(pattern);
+  const rootDir = path
+    .resolve(isDir ? args.path : path.dirname(args.path))
+    .replace("/**", "");
+  return {
+    files: files.map((file) => path.resolve(file)),
+    rootDir,
+  };
 }

--- a/tests/globs/declarations/a/bar.ts
+++ b/tests/globs/declarations/a/bar.ts
@@ -1,0 +1,3 @@
+export type Bar = {
+  a: string;
+};

--- a/tests/globs/declarations/a/foo.d.ts
+++ b/tests/globs/declarations/a/foo.d.ts
@@ -1,0 +1,3 @@
+export type Foo = {
+  a: string;
+};

--- a/tests/globs/declarations/b/baz.d.ts
+++ b/tests/globs/declarations/b/baz.d.ts
@@ -1,0 +1,3 @@
+export type Baz = {
+  a: string;
+};


### PR DESCRIPTION
Should allow e.g. "**/*.d.ts" as a valid path entry.